### PR TITLE
Fix invalid composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,5 @@
 
 	"autoload" : {
 		"files" : [ "wp-cli-rename-db-prefix.php" ]
-	},
+	}
 }


### PR DESCRIPTION
True JSON means no trailing commas

From https://github.com/wp-cli/package-index/pull/62#issuecomment-233670118
