### PR TITLE
Add a --no-prompt flag to allow for unattended script usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ A [WP-CLI](http://wp-cli.org/) command to rename WordPress' database prefix.
 
 `wp rename-db-prefix <new_prefix>`
 
-You will be prompted for confirmation before the command makes any changes.
+`wp rename-db-prefix --dry-run <new_prefix>`
+
+`wp rename-db-prefix --no-prompt <new_prefix>`
+
+You will be prompted for confirmation before the command makes any changes unless using --no-prompt flag.
 
 ## Warning
 

--- a/wp-cli-rename-db-prefix.php
+++ b/wp-cli-rename-db-prefix.php
@@ -32,6 +32,7 @@ class WP_CLI_Rename_DB_Prefix extends \WP_CLI_Command {
 	public $new_prefix;
 
 	public $is_dry_run = false;
+	public $is_no_prompt = false;
 
 	/**
 	 * Rename WordPress' database prefix.
@@ -46,6 +47,9 @@ class WP_CLI_Rename_DB_Prefix extends \WP_CLI_Command {
 	 * [--dry-run]
 	 * : Preview which data would be updated.
 	 *
+	 * [--no-prompt]
+	 * : Skip asking for confirmation. 
+	 *
 	 * ## EXAMPLES
 	 *
 	 * wp rename-db-prefix foo_
@@ -57,6 +61,7 @@ class WP_CLI_Rename_DB_Prefix extends \WP_CLI_Command {
 		global $wpdb;
 
 		$this->is_dry_run = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
+		$this->is_no_prompt = \WP_CLI\Utils\get_flag_value( $assoc_args, 'no-prompt', false );
 
 		wp_debug_mode();    // re-set `display_errors` after WP-CLI overrides it, see https://github.com/wp-cli/wp-cli/issues/706#issuecomment-203610437
 
@@ -98,7 +103,11 @@ class WP_CLI_Rename_DB_Prefix extends \WP_CLI_Command {
 			\WP_CLI::line( 'Running in dry run mode.' );
 			return;
 		}
-
+		
+		if ( $this->is_no_prompt ) {
+			return;
+		}
+		
 		\WP_CLI::warning( "Use this at your own risk. If something goes wrong, it could break your site. Before running this, make sure to back up your `wp-config.php` file and run `wp db export`." );
 
 		\WP_CLI::confirm( sprintf(


### PR DESCRIPTION
I use this script often but find myself having to confirm execution even though its ran within a larger script. This option allows for the ability to not have to stand by.