### PR TITLE
Add --no-config-update option to skip updating wp-config.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,10 @@ A [WP-CLI](http://wp-cli.org/) command to rename WordPress' database prefix.
 
 `wp rename-db-prefix <new_prefix>`
 
-`wp rename-db-prefix --dry-run <new_prefix>`
+`wp rename-db-prefix <new_prefix> [--dry-run] [--no-prompt] [--no-config-update]`
 
-`wp rename-db-prefix --no-prompt <new_prefix>`
-
-You will be prompted for confirmation before the command makes any changes unless using --no-prompt flag.
+You will be prompted for confirmation before the command makes any changes unless using --no-prompt flag.  
+Using the --no-config-update option will not update your `wp-config.php` (useful for non-standard environments).
 
 ## Warning
 

--- a/wp-cli-rename-db-prefix.php
+++ b/wp-cli-rename-db-prefix.php
@@ -33,6 +33,7 @@ class WP_CLI_Rename_DB_Prefix extends \WP_CLI_Command {
 
 	public $is_dry_run = false;
 	public $is_no_prompt = false;
+	public $is_no_config_update = false;
 
 	/**
 	 * Rename WordPress' database prefix.
@@ -50,6 +51,9 @@ class WP_CLI_Rename_DB_Prefix extends \WP_CLI_Command {
 	 * [--no-prompt]
 	 * : Skip asking for confirmation. 
 	 *
+	 * [--no-config-update]
+	 * : Skip updating wp-config.php
+	 *
 	 * ## EXAMPLES
 	 *
 	 * wp rename-db-prefix foo_
@@ -62,6 +66,7 @@ class WP_CLI_Rename_DB_Prefix extends \WP_CLI_Command {
 
 		$this->is_dry_run = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
 		$this->is_no_prompt = \WP_CLI\Utils\get_flag_value( $assoc_args, 'no-prompt', false );
+		$this->is_no_config_update = \WP_CLI\Utils\get_flag_value( $assoc_args, 'no-config-update', false );
 
 		wp_debug_mode();    // re-set `display_errors` after WP-CLI overrides it, see https://github.com/wp-cli/wp-cli/issues/706#issuecomment-203610437
 
@@ -125,6 +130,11 @@ class WP_CLI_Rename_DB_Prefix extends \WP_CLI_Command {
 	 */
 	protected function update_wp_config() {
 		if ( $this->is_dry_run ) {
+			return;
+		}
+		
+		if ( $this->is_no_config_update ) {
+			\WP_CLI::line( 'Skipping wp-config.php update as requested.' );
 			return;
 		}
 

--- a/wp-cli-rename-db-prefix.php
+++ b/wp-cli-rename-db-prefix.php
@@ -32,8 +32,8 @@ class WP_CLI_Rename_DB_Prefix extends \WP_CLI_Command {
 	public $new_prefix;
 
 	public $is_dry_run = false;
-	public $is_no_prompt = false;
-	public $is_no_config_update = false;
+	public $is_prompt = true;
+	public $is_config_update = true;
 
 	/**
 	 * Rename WordPress' database prefix.
@@ -47,12 +47,15 @@ class WP_CLI_Rename_DB_Prefix extends \WP_CLI_Command {
 	 *
 	 * [--dry-run]
 	 * : Preview which data would be updated.
+	 * default: false
 	 *
-	 * [--no-prompt]
-	 * : Skip asking for confirmation. 
+	 * [--prompt]
+	 * : Ask for confirmation.
+	 * default: true
 	 *
-	 * [--no-config-update]
-	 * : Skip updating wp-config.php
+	 * [--config-update]
+	 * : updates wp-config.php.
+	 * default: true
 	 *
 	 * ## EXAMPLES
 	 *
@@ -65,8 +68,8 @@ class WP_CLI_Rename_DB_Prefix extends \WP_CLI_Command {
 		global $wpdb;
 
 		$this->is_dry_run = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
-		$this->is_no_prompt = \WP_CLI\Utils\get_flag_value( $assoc_args, 'no-prompt', false );
-		$this->is_no_config_update = \WP_CLI\Utils\get_flag_value( $assoc_args, 'no-config-update', false );
+		$this->is_prompt = \WP_CLI\Utils\get_flag_value( $assoc_args, 'prompt', true );
+		$this->is_config_update = \WP_CLI\Utils\get_flag_value( $assoc_args, 'config-update', true );
 
 		wp_debug_mode();    // re-set `display_errors` after WP-CLI overrides it, see https://github.com/wp-cli/wp-cli/issues/706#issuecomment-203610437
 
@@ -109,7 +112,7 @@ class WP_CLI_Rename_DB_Prefix extends \WP_CLI_Command {
 			return;
 		}
 		
-		if ( $this->is_no_prompt ) {
+		if ( ! $this->is_prompt ) {
 			return;
 		}
 		
@@ -133,7 +136,7 @@ class WP_CLI_Rename_DB_Prefix extends \WP_CLI_Command {
 			return;
 		}
 		
-		if ( $this->is_no_config_update ) {
+		if ( ! $this->is_config_update ) {
 			\WP_CLI::line( 'Skipping wp-config.php update as requested.' );
 			return;
 		}


### PR DESCRIPTION
Skipping `wp-config.php` update is useful in non-standard environments like [Bedrock](https://roots.io/bedrock/).

Also, make `--no-prompt` actually work (`--no` flags should be treated as positive flags as stated in https://make.wordpress.org/cli/handbook/commands-cookbook/#accepting-arguments).