### PR TITLE
Issue 15 no prompt does not works as expected documentation needs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ A [WP-CLI](http://wp-cli.org/) command to rename WordPress' database prefix.
 
 `wp rename-db-prefix <new_prefix>`
 
-`wp rename-db-prefix <new_prefix> [--dry-run] [--no-prompt] [--no-config-update]`
+`wp rename-db-prefix <new_prefix> [--dry-run] [--no-confirm] [--no-config-update]`
 
-You will be prompted for confirmation before the command makes any changes unless using --no-prompt flag.  
+You will be prompted for confirmation before the command makes any changes unless using --no-confirm flag.  
 Using the --no-config-update option will not update your `wp-config.php` (useful for non-standard environments).
 
 ## Warning

--- a/wp-cli-rename-db-prefix.php
+++ b/wp-cli-rename-db-prefix.php
@@ -68,7 +68,7 @@ class WP_CLI_Rename_DB_Prefix extends \WP_CLI_Command {
 		global $wpdb;
 
 		$this->is_dry_run       = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
-		$this->is_prompt        = \WP_CLI\Utils\get_flag_value( $assoc_args, 'prompt', true );
+		$this->is_prompt        = \WP_CLI\Utils\get_flag_value( $assoc_args, 'confirm', true );
 		$this->is_config_update = \WP_CLI\Utils\get_flag_value( $assoc_args, 'config-update', true );
 
 		wp_debug_mode();    // re-set `display_errors` after WP-CLI overrides it, see https://github.com/wp-cli/wp-cli/issues/706#issuecomment-203610437

--- a/wp-cli-rename-db-prefix.php
+++ b/wp-cli-rename-db-prefix.php
@@ -49,7 +49,7 @@ class WP_CLI_Rename_DB_Prefix extends \WP_CLI_Command {
 	 * : Preview which data would be updated.
 	 * default: false
 	 *
-	 * [--prompt]
+	 * [--confirm]
 	 * : Ask for confirmation.
 	 * default: true
 	 *


### PR DESCRIPTION
Fixes #15 : non-working `--prompt` / `--no-prompt` flag, by renaming it to `--confirm` / `--no-confirm`.